### PR TITLE
Use different mapping from spring properties to vault paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,27 +17,57 @@ application.properties file. You can find them in the <a href="#properties">appl
 In Vault the App ID authentication backend has to be enabled. In this context tuples of app-ids and user-ids have to be 
 created in Vault.
 
-Each property you want to save in vault must be created as a single secret under an individual secret path sharing the 
-same prefix. The last part of the secret-path will be the property key. The property value can be saved in the 
-underlying JSON-Property named "value" or any other key, which must be declared in the properties with an '@' infix (e.g. secretKey@fieldname).
+For further vault documentation see <a href="http://www.vaultproject.io/">http://www.vaultproject.io/</a>
+
+## <a name="mapping">Spring property mapping</a>
+
+All properties you want to save in vault must be located under the same parent path. You can configure the parent path by
+setting the configuration property **edison.vault.secret-path**
+
+Each spring property you want to load from vault has to be added to the configuration property **edison.vault.properties**.
+
+An individual spring property is mapped to a vault path by the following scheme:
+
+1) Every dot (".") is replaced by a slash ("/").
+2) The part before the last slash is the sub-path of the property and has to exist in vault.
+3) The part after the last slash is the json field name of the vault value.
+
 
 Example
 
-    GET http://yourVaultHostName:4001/v1/some/secret/path/secretOne 
+    application.properties:
+        ...
+        edison.vault.secret-path=/my/secret/path/
+        edison.vault.properties=my-secret-value,my.secret.value,my.secret.othervalue
+        ...
+    
+    "my-secret-value" is mapped to:
+    GET http://yourVaultHostName:4001/v1/my/secret/path
     {
-      "key1": "theSecretNumberOne",
-      "key2": "theOtherSecretNumberOne",
-      "value": "defaultSecretNumberOne"
+      "my-secret-value": "theFirstSecretValueYouWant"
     }
-  
-    GET http://yourVaultHostName:4001/v1/some/secret/path/secretTwo 
+    
+    "my.secret.value" is mapped to:
+    GET http://yourVaultHostName:4001/v1/my/secret/path/my/secret/
     {
-      "value": "theSecretNumberTwo"
+        "value": "theSecondSecretValueYouWant"
+    }
+    
+    "my.secret.othervalue" is mapped to:
+    GET http://yourVaultHostName:4001/v1/my/secret/path/my/secret/
+    {
+        "othervalue": "theThirdSecretValueYouWant"
     }
 
-In this example you will get two properties: secretOne=theSecretNumberOne and secretTwo=theSecretNumberTwo
 
-For further vault documentation see <a href="http://www.vaultproject.io/">http://www.vaultproject.io/</a> 
+In this example you will get three spring properties with the following values:
+
+- my-secret-value=theFirstSecretValueYouWant
+- my.secret.value=theSecondSecretValueYouWant
+- my.secret.othervalue=theThirdSecretValueYouWant
+
+You see how the parent secret-path is used and how a spring property key is mapped to a vault path.
+Notice the difference between *my-secret-value* and *my.secret.value*.
 
 ## <a name="properties">application.properties configuration</a>
 
@@ -57,7 +87,7 @@ application.properties:
 
     edison.vault.enabled=true
     edison.vault.base-url=https://yourVaultHostName:8200
-    edison.vault.secret-path=/some/secret/path/
+    edison.vault.secret-path=/my/secret/path/
     edison.vault.properties=secretOne@key1,secretOne@key2,secretTwo,secretOne
     edison.vault.token-source=login
     edison.vault.appid=aaaaaaaa-bbbb-cccc-dddd-eeeeeeffffff

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ apply plugin: 'signing'
 apply plugin: 'maven'
 apply from: 'dependencies.gradle'
 
-version='1.4.0'
+version='2.0.0-SNAPSHOT'
 group='de.otto.edison'
 
 repositories {

--- a/example/src/main/resources/application.properties
+++ b/example/src/main/resources/application.properties
@@ -3,6 +3,6 @@ edison.vault.base-url=http://127.0.0.1:8200
 edison.vault.token-source=login
 edison.vault.enableconfigurer=true
 edison.vault.secret-path=/secret
-edison.vault.properties=keyOne,keyTwo,keyThree
+edison.vault.properties=keyOne.value,keyTwo.value,keyThree.value
 edison.vault.appid=test-app-id
 edison.vault.userid=test-user-id

--- a/example/src/test/java/de/otto/edison/vault/example/ExampleApplicationTests.java
+++ b/example/src/test/java/de/otto/edison/vault/example/ExampleApplicationTests.java
@@ -15,13 +15,13 @@ import static org.hamcrest.core.Is.is;
 @SpringApplicationConfiguration(classes = ExampleApplication.class)
 public class ExampleApplicationTests {
 
-    @Value("${keyOne}")
+    @Value("${keyOne.value}")
     private String secretOne;
 
-    @Value("${keyTwo}")
+    @Value("${keyTwo.value}")
     private String secretTwo;
 
-    @Value("${keyThree}")
+    @Value("${keyThree.value}")
     private String secretThree;
 
     @Test

--- a/example/src/test/java/de/otto/edison/vault/example/ExampleApplicationTests.java
+++ b/example/src/test/java/de/otto/edison/vault/example/ExampleApplicationTests.java
@@ -13,7 +13,7 @@ import static org.hamcrest.core.Is.is;
 @ComponentScan("de.otto.edison.vault")
 @RunWith(SpringJUnit4ClassRunner.class)
 @SpringApplicationConfiguration(classes = ExampleApplication.class)
-public class ExampleApplicationTests  {
+public class ExampleApplicationTests {
 
     @Value("${keyOne}")
     private String secretOne;
@@ -24,10 +24,10 @@ public class ExampleApplicationTests  {
     @Value("${keyThree}")
     private String secretThree;
 
-	@Test
-	public void shouldHaveWiredValues() {
-		assertThat(secretOne, is("secretNumberOne"));
-		assertThat(secretTwo, is("secretNumberTwo"));
-		assertThat(secretThree, is("secretNumberThree"));
-	}
+    @Test
+    public void shouldHaveWiredValues() {
+        assertThat(secretOne, is("secretNumberOne"));
+        assertThat(secretTwo, is("secretNumberTwo"));
+        assertThat(secretThree, is("secretNumberThree"));
+    }
 }

--- a/src/main/java/de/otto/edison/vault/ConfigProperties.java
+++ b/src/main/java/de/otto/edison/vault/ConfigProperties.java
@@ -3,10 +3,18 @@ package de.otto.edison.vault;
 import org.springframework.core.env.Environment;
 import org.springframework.util.StringUtils;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 public class ConfigProperties {
+
     private final boolean enabled;
     private final String baseUrl;
     private final String secretPath;
@@ -23,7 +31,7 @@ public class ConfigProperties {
         final String baseUrlProperty = environment.getProperty("edison.vault.base-url");
         baseUrl = StringUtils.isEmpty(baseUrlProperty) ? getVaultAddrFromEnv() : baseUrlProperty;
         secretPath = environment.getProperty("edison.vault.secret-path");
-        properties = buildPropertyMap( splitVaultPropertyKeys(environment.getProperty("edison.vault.properties")));
+        properties = buildPropertyMap(splitVaultPropertyKeys(environment.getProperty("edison.vault.properties")));
         tokenSource = environment.getProperty("edison.vault.token-source");
         environmentToken = environment.getProperty("edison.vault.environment-token");
         fileToken = environment.getProperty("edison.vault.file-token");
@@ -81,14 +89,14 @@ public class ConfigProperties {
         if (StringUtils.isEmpty(properties)) {
             return new ArrayList<>();
         }
-        return Arrays.asList(properties.split(",")).stream().map(String::trim).filter(s -> !s.isEmpty()).collect(Collectors.toList());
+        return Arrays.stream(properties.split(",")).map(String::trim).filter(s -> !s.isEmpty()).collect(Collectors.toList());
     }
 
     private Map<String, Set<String>> buildPropertyMap(List<String> properties) {
-        Map<String, Set<String>> result = new HashMap<>();
-        for (String property: properties) {
+        final Map<String, Set<String>> result = new HashMap<>();
+        for (final String property : properties) {
             final String[] keyAndFieldname = property.split("@");
-            if(keyAndFieldname.length > 0) {
+            if (keyAndFieldname.length > 0) {
                 final String key = keyAndFieldname[0];
                 final Set<String> fieldnames = result.getOrDefault(key, new HashSet<>());
                 if (keyAndFieldname.length > 1) {
@@ -104,23 +112,43 @@ public class ConfigProperties {
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
 
         ConfigProperties that = (ConfigProperties) o;
 
-        if (enabled != that.enabled) return false;
-        if (baseUrl != null ? !baseUrl.equals(that.baseUrl) : that.baseUrl != null) return false;
-        if (secretPath != null ? !secretPath.equals(that.secretPath) : that.secretPath != null) return false;
-        if (properties != null ? !properties.equals(that.properties) : that.properties != null) return false;
-        if (tokenSource != null ? !tokenSource.equals(that.tokenSource) : that.tokenSource != null) return false;
-        if (environmentToken != null ? !environmentToken.equals(that.environmentToken) : that.environmentToken != null)
+        if (enabled != that.enabled) {
             return false;
-        if (fileToken != null ? !fileToken.equals(that.fileToken) : that.fileToken != null) return false;
-        if (appId != null ? !appId.equals(that.appId) : that.appId != null) return false;
-        if (userId != null ? !userId.equals(that.userId) : that.userId != null) return false;
+        }
+        if (baseUrl != null ? !baseUrl.equals(that.baseUrl) : that.baseUrl != null) {
+            return false;
+        }
+        if (secretPath != null ? !secretPath.equals(that.secretPath) : that.secretPath != null) {
+            return false;
+        }
+        if (properties != null ? !properties.equals(that.properties) : that.properties != null) {
+            return false;
+        }
+        if (tokenSource != null ? !tokenSource.equals(that.tokenSource) : that.tokenSource != null) {
+            return false;
+        }
+        if (environmentToken != null ? !environmentToken.equals(that.environmentToken) : that.environmentToken != null) {
+            return false;
+        }
+        if (fileToken != null ? !fileToken.equals(that.fileToken) : that.fileToken != null) {
+            return false;
+        }
+        if (appId != null ? !appId.equals(that.appId) : that.appId != null) {
+            return false;
+        }
+        if (userId != null ? !userId.equals(that.userId) : that.userId != null) {
+            return false;
+        }
         return defaultVaultToken != null ? defaultVaultToken.equals(that.defaultVaultToken) : that.defaultVaultToken == null;
-
     }
 
     @Override

--- a/src/main/java/de/otto/edison/vault/VaultClient.java
+++ b/src/main/java/de/otto/edison/vault/VaultClient.java
@@ -35,11 +35,7 @@ public class VaultClient {
         this.vaultToken = vaultToken;
     }
 
-    public String read(final String key) {
-        return readField(key, "value").orElse(null);
-    }
-
-    public Optional<String> readField(final String key, final String field) {
+    public Map<String,String> readFields(final String key) {
         try {
             final String url = vaultBaseUrl + "/v1/" + secretPath + "/" + key;
             final Response response = asyncHttpClient
@@ -53,18 +49,16 @@ public class VaultClient {
             }
             LOG.info("read of vault property '{}' successful", key);
 
-            return extractField(response.getResponseBody(), field);
+            return extractFields(response.getResponseBody());
         } catch (ExecutionException | InterruptedException | IOException e) {
             LOG.error(String.format("extract of vault property '%s' failed", key), e);
             throw new RuntimeException(e);
         }
     }
 
-    private Optional<String> extractField(final String responseBody, final String field) {
+    private Map<String,String> extractFields(final String responseBody) {
         Map<String, Object> responseMap = new Gson().fromJson(responseBody, Map.class);
-        Map<String, String> data = (Map<String, String>) responseMap.get("data");
-
-        return Optional.ofNullable(data.get(field));
+        return (Map<String, String>) responseMap.get("data");
     }
 
     private String removeTrailingSlash(final String url) {

--- a/src/main/java/de/otto/edison/vault/VaultClient.java
+++ b/src/main/java/de/otto/edison/vault/VaultClient.java
@@ -37,7 +37,12 @@ public class VaultClient {
 
     public Map<String,String> readFields(final String key) {
         try {
-            final String url = vaultBaseUrl + "/v1/" + secretPath + "/" + key;
+            final String url;
+            if (key != null && !key.isEmpty()) {
+                url = vaultBaseUrl + "/v1/" + secretPath + "/" + key;
+            } else {
+                url = vaultBaseUrl + "/v1/" + secretPath;
+            }
             final Response response = asyncHttpClient
                     .prepareGet(url)
                     .setHeader("X-Vault-Token", vaultToken)

--- a/src/main/java/de/otto/edison/vault/VaultReader.java
+++ b/src/main/java/de/otto/edison/vault/VaultReader.java
@@ -11,8 +11,6 @@ public class VaultReader {
     private final ConfigProperties configProperties;
     private final VaultClient vaultClient;
 
-    private Logger LOG = LoggerFactory.getLogger(VaultReader.class);
-
     public VaultReader(final ConfigProperties configProperties, VaultClient vaultClient) {
         this.configProperties = configProperties;
         this.vaultClient = vaultClient;

--- a/src/main/java/de/otto/edison/vault/VaultReader.java
+++ b/src/main/java/de/otto/edison/vault/VaultReader.java
@@ -5,8 +5,11 @@ import org.slf4j.LoggerFactory;
 
 import java.util.Map;
 import java.util.Properties;
+import java.util.stream.Collectors;
 
 public class VaultReader {
+
+    private static final Logger LOG = LoggerFactory.getLogger(VaultReader.class);
 
     private final ConfigProperties configProperties;
     private final VaultClient vaultClient;
@@ -21,16 +24,59 @@ public class VaultReader {
     }
 
     public Properties fetchPropertiesFromVault() {
+
         final Properties vaultProperties = new Properties();
-        configProperties.getProperties().forEach(key ->
-                configProperties.getPropertyFieldnames(key).forEach(field -> {
-                    final Map<String, String> fields = vaultClient.readFields(key);
-                    final String fieldValue = fields.get(field);
-                    if (field.equals("value")) {
-                        vaultProperties.setProperty(key, fieldValue);
-                    }
-                    vaultProperties.setProperty(key + "@" + field, fieldValue);
-                }));
+        configProperties.getProperties()
+                .stream()
+                .map(VaultFieldInfo::new)
+                .collect(Collectors.groupingBy(VaultFieldInfo::getVaultSecretPathName))
+                .forEach(
+                        (vaultSecretPath, fields) -> {
+                            final Map<String, String> vaultFieldValues = vaultClient.readFields(vaultSecretPath);
+                            fields.forEach(field -> {
+                                final String vaultFieldValue = vaultFieldValues.get(field.getVaultFieldName());
+                                if (vaultFieldValue != null) {
+                                    LOG.info("read of value '{}' from vault property '{}' successful",
+                                            field.getVaultFieldName(),
+                                            field.getVaultSecretPathName());
+                                    vaultProperties.put(field.getSpringPropertyPath(), vaultFieldValue);
+                                } else {
+                                    throw new RuntimeException("unable read value '" + field.getVaultFieldName() +
+                                            " ' from vault property ' " + field.getVaultSecretPathName() + "' - value not found");
+                                }
+                            });
+                        });
         return vaultProperties;
+    }
+
+    private static class VaultFieldInfo {
+
+        private final String vaultSecretPathName;
+        private final String vaultFieldName;
+        private final String springPropertyPath;
+
+        VaultFieldInfo(String springPropertyPath) {
+            final int lastDotIndex = springPropertyPath.lastIndexOf(".");
+            if (lastDotIndex >= 0) {
+                this.vaultSecretPathName = springPropertyPath.substring(0, lastDotIndex).replace(".", "/");
+                this.vaultFieldName = springPropertyPath.substring(lastDotIndex + 1);
+            } else {
+                this.vaultSecretPathName = "";
+                this.vaultFieldName = springPropertyPath;
+            }
+            this.springPropertyPath = springPropertyPath;
+        }
+
+        String getVaultSecretPathName() {
+            return vaultSecretPathName;
+        }
+
+        String getVaultFieldName() {
+            return vaultFieldName;
+        }
+
+        String getSpringPropertyPath() {
+            return springPropertyPath;
+        }
     }
 }

--- a/src/main/java/de/otto/edison/vault/VaultReader.java
+++ b/src/main/java/de/otto/edison/vault/VaultReader.java
@@ -3,6 +3,7 @@ package de.otto.edison.vault;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.Map;
 import java.util.Properties;
 
 public class VaultReader {
@@ -23,16 +24,15 @@ public class VaultReader {
 
     public Properties fetchPropertiesFromVault() {
         final Properties vaultProperties = new Properties();
-        configProperties.getProperties().forEach(key -> {
-            configProperties.getPropertyFieldnames(key).forEach(field -> {
-                final String secret = vaultClient.readField(key, field).orElse(null);
-                if(field.equals("value")) {
-                    vaultProperties.setProperty(key, secret);
-                }
-                vaultProperties.setProperty(key + "@" + field, secret);
-            });
-        });
+        configProperties.getProperties().forEach(key ->
+                configProperties.getPropertyFieldnames(key).forEach(field -> {
+                    final Map<String, String> fields = vaultClient.readFields(key);
+                    final String fieldValue = fields.get(field);
+                    if (field.equals("value")) {
+                        vaultProperties.setProperty(key, fieldValue);
+                    }
+                    vaultProperties.setProperty(key + "@" + field, fieldValue);
+                }));
         return vaultProperties;
     }
-
 }

--- a/src/test/java/de/otto/edison/vault/ConfigPropertiesTest.java
+++ b/src/test/java/de/otto/edison/vault/ConfigPropertiesTest.java
@@ -20,7 +20,7 @@ public class ConfigPropertiesTest {
         when(environment.getProperty("edison.vault.enabled")).thenReturn("true");
         when(environment.getProperty("edison.vault.base-url")).thenReturn("someBaseUrl");
         when(environment.getProperty("edison.vault.secret-path")).thenReturn("someSecretPath");
-        when(environment.getProperty("edison.vault.properties")).thenReturn("keyOne@key1, keyOne,keyTwo ,keyThree@value,keyFour@key4");
+        when(environment.getProperty("edison.vault.properties")).thenReturn("keyOne.key1, keyOne, keyTwo, keyThree.value, keyFour.key4");
         when(environment.getProperty("edison.vault.token-source")).thenReturn("file");
         when(environment.getProperty("edison.vault.environment-token")).thenReturn("someEnvVariable");
         when(environment.getProperty("edison.vault.file-token")).thenReturn("someFile");
@@ -34,16 +34,8 @@ public class ConfigPropertiesTest {
         assertThat(testee.isEnabled(), is(true));
         assertThat(testee.getBaseUrl(), is("someBaseUrl"));
         assertThat(testee.getSecretPath(), is("someSecretPath"));
-        assertThat(testee.getProperties(), Matchers.hasSize(4));
-        assertThat(testee.getProperties(), hasItems("keyOne", "keyTwo", "keyThree", "keyFour"));
-        assertThat(testee.getPropertyFieldnames("keyOne"), hasItems("key1","value"));
-        assertThat(testee.getPropertyFieldnames("keyOne"), hasSize(2));
-        assertThat(testee.getPropertyFieldnames("keyTwo"), hasItems("value"));
-        assertThat(testee.getPropertyFieldnames("keyTwo"), hasSize(1));
-        assertThat(testee.getPropertyFieldnames("keyThree"), hasItems("value"));
-        assertThat(testee.getPropertyFieldnames("keyThree"), hasSize(1));
-        assertThat(testee.getPropertyFieldnames("keyFour"), hasItems("key4"));
-        assertThat(testee.getPropertyFieldnames("keyFour"), hasSize(1));
+        assertThat(testee.getProperties(), Matchers.hasSize(5));
+        assertThat(testee.getProperties(), hasItems("keyOne.key1","keyOne", "keyTwo", "keyThree.value", "keyFour.key4"));
         assertThat(testee.getTokenSource(), is("file"));
         assertThat(testee.getAppId(), is("someAppId"));
         assertThat(testee.getUserId(), is("someUserId"));

--- a/src/test/java/de/otto/edison/vault/VaultClientTest.java
+++ b/src/test/java/de/otto/edison/vault/VaultClientTest.java
@@ -9,6 +9,7 @@ import org.testng.annotations.Test;
 import java.util.Optional;
 
 import static de.otto.edison.vault.VaultClient.vaultClient;
+import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
@@ -40,7 +41,7 @@ public class VaultClientTest {
 
         Response response = mock(Response.class);
         AsyncHttpClient.BoundRequestBuilder boundRequestBuilder = mock(AsyncHttpClient.BoundRequestBuilder.class);
-        ListenableFuture listenableFuture = mock(ListenableFuture.class);
+        ListenableFuture<Response> listenableFuture = mock(ListenableFuture.class);
 
         when(response.getStatusCode()).thenReturn(200);
         when(response.getResponseBody()).thenReturn(createReadResponse("someKey", "value", "someValue"));
@@ -50,7 +51,7 @@ public class VaultClientTest {
         when(listenableFuture.get()).thenReturn(response);
 
         // when
-        String propertyValue = testee.read("someKey");
+        String propertyValue = testee.readFields("someKey").get("value");
 
         // then
         assertThat(propertyValue, is("someValue"));
@@ -67,7 +68,7 @@ public class VaultClientTest {
 
         Response response = mock(Response.class);
         AsyncHttpClient.BoundRequestBuilder boundRequestBuilder = mock(AsyncHttpClient.BoundRequestBuilder.class);
-        ListenableFuture listenableFuture = mock(ListenableFuture.class);
+        ListenableFuture<Response> listenableFuture = mock(ListenableFuture.class);
 
         when(response.getStatusCode()).thenReturn(200);
         when(response.getResponseBody()).thenReturn(createReadResponse("someKey", "someField", "someValue"));
@@ -77,7 +78,7 @@ public class VaultClientTest {
         when(listenableFuture.get()).thenReturn(response);
 
         // when
-        String fieldValue = testee.read("someKey");
+        String fieldValue = testee.readFields("someKey").get("value");
 
         // then
         assertThat(fieldValue, is(nullValue()));
@@ -94,7 +95,7 @@ public class VaultClientTest {
 
         Response response = mock(Response.class);
         AsyncHttpClient.BoundRequestBuilder boundRequestBuilder = mock(AsyncHttpClient.BoundRequestBuilder.class);
-        ListenableFuture listenableFuture = mock(ListenableFuture.class);
+        ListenableFuture<Response> listenableFuture = mock(ListenableFuture.class);
 
         when(response.getStatusCode()).thenReturn(200);
         when(response.getResponseBody()).thenReturn(createReadResponse("someKey", "someFieldOtherThanValue", "someValue"));
@@ -104,11 +105,11 @@ public class VaultClientTest {
         when(listenableFuture.get()).thenReturn(response);
 
         // when
-        Optional<String> fieldValue = testee.readField("someKey", "someFieldOtherThanValue");
+        String fieldValue = testee.readFields("someKey").get("someFieldOtherThanValue");
 
         // then
-        assertThat(fieldValue.isPresent(), is(true));
-        assertThat(fieldValue.get(), is("someValue"));
+        assertThat(fieldValue, notNullValue());
+        assertThat(fieldValue, is("someValue"));
     }
 
     @Test
@@ -122,7 +123,7 @@ public class VaultClientTest {
 
         Response response = mock(Response.class);
         AsyncHttpClient.BoundRequestBuilder boundRequestBuilder = mock(AsyncHttpClient.BoundRequestBuilder.class);
-        ListenableFuture listenableFuture = mock(ListenableFuture.class);
+        ListenableFuture<Response> listenableFuture = mock(ListenableFuture.class);
 
         when(response.getStatusCode()).thenReturn(200);
         when(response.getResponseBody()).thenReturn(createReadResponse("someKey", "someField", "someValue"));
@@ -132,10 +133,10 @@ public class VaultClientTest {
         when(listenableFuture.get()).thenReturn(response);
 
         // when
-        Optional<String> fieldValue = testee.readField("someKey", "someUnknownField");
+        String fieldValue = testee.readFields("someKey").get("someUnknownField");
 
         // then
-        assertThat(fieldValue.isPresent(), is(false));
+        assertThat(fieldValue, nullValue());
     }
 
     private String createReadResponse(final String key, final String field, final String value) {
@@ -153,7 +154,7 @@ public class VaultClientTest {
 
         Response response = mock(Response.class);
         AsyncHttpClient.BoundRequestBuilder boundRequestBuilder = mock(AsyncHttpClient.BoundRequestBuilder.class);
-        ListenableFuture listenableFuture = mock(ListenableFuture.class);
+        ListenableFuture<Response> listenableFuture = mock(ListenableFuture.class);
 
         when(response.getResponseBody()).thenReturn(null);
         when(response.getStatusCode()).thenReturn(500);
@@ -164,7 +165,7 @@ public class VaultClientTest {
 
         // when
         try {
-            testee.read("someKey");
+            testee.readFields("someKey");
             fail();
         } catch (RuntimeException e) {
             // then
@@ -182,7 +183,7 @@ public class VaultClientTest {
         testee.asyncHttpClient = asyncHttpClient;
 
         // when
-        testee.read("someKey");
+        testee.readFields("someKey");
 
         // then
         verify(asyncHttpClient).prepareGet("http://someBaseUrl/v1/someSecretPath/someKey");
@@ -198,7 +199,7 @@ public class VaultClientTest {
         testee.asyncHttpClient = asyncHttpClient;
 
         // when
-        testee.read("someKey");
+        testee.readFields("someKey");
 
         // then
         verify(asyncHttpClient).prepareGet("http://someBaseUrl/v1/someSecretPath/someKey");

--- a/src/test/java/de/otto/edison/vault/VaultClientTest.java
+++ b/src/test/java/de/otto/edison/vault/VaultClientTest.java
@@ -21,7 +21,6 @@ public class VaultClientTest {
 
     private VaultClient testee;
     private AsyncHttpClient asyncHttpClient;
-    private VaultTokenReader vaultTokenReader;
     private ConfigProperties configProperties;
 
     @BeforeMethod

--- a/src/test/java/de/otto/edison/vault/VaultReaderTest.java
+++ b/src/test/java/de/otto/edison/vault/VaultReaderTest.java
@@ -5,8 +5,15 @@ import org.powermock.modules.testng.PowerMockTestCase;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
-import java.util.*;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Properties;
+import java.util.Set;
 
+import static java.util.Collections.singletonMap;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 import static org.powermock.api.mockito.PowerMockito.mock;
@@ -35,13 +42,16 @@ public class VaultReaderTest extends PowerMockTestCase {
         propertiesToRead.add("someKey3");
 
         when(configProperties.getProperties()).thenReturn(propertiesToRead);
-        when(configProperties.getPropertyFieldnames("someKey1")).thenReturn(new HashSet<String>(Arrays.asList("value")));
-        when(configProperties.getPropertyFieldnames("someKey2")).thenReturn(new HashSet<String>(Arrays.asList("value")));
-        when(configProperties.getPropertyFieldnames("someKey3")).thenReturn(new HashSet<String>(Arrays.asList("field3", "field3_2")));
-        when(vaultClient.readField("someKey1", "value")).thenReturn(Optional.of("someValue1"));
-        when(vaultClient.readField("someKey2", "value")).thenReturn(Optional.of("someValue2"));
-        when(vaultClient.readField("someKey3", "field3")).thenReturn(Optional.of("someValue3"));
-        when(vaultClient.readField("someKey3", "field3_2")).thenReturn(Optional.of("someValue3_2"));
+        when(configProperties.getPropertyFieldnames("someKey1")).thenReturn(new HashSet<>(Arrays.asList("value")));
+        when(configProperties.getPropertyFieldnames("someKey2")).thenReturn(new HashSet<>(Arrays.asList("value")));
+        when(configProperties.getPropertyFieldnames("someKey3")).thenReturn(new HashSet<>(Arrays.asList("field3", "field3_2")));
+        when(vaultClient.readFields("someKey1")).thenReturn(singletonMap("value", "someValue1"));
+        when(vaultClient.readFields("someKey2")).thenReturn(singletonMap("value", "someValue2"));
+
+        final Map<String, String> someKey3Values = new HashMap<>();
+        someKey3Values.put("field3", "someValue3");
+        someKey3Values.put("field3_2", "someValue3_2");
+        when(vaultClient.readFields("someKey3")).thenReturn(someKey3Values);
 
         // when
         Properties properties = testee.fetchPropertiesFromVault();
@@ -57,5 +67,4 @@ public class VaultReaderTest extends PowerMockTestCase {
 
         assertThat(properties, is(expectedProperties));
     }
-
 }

--- a/src/test/java/de/otto/edison/vault/VaultReaderTest.java
+++ b/src/test/java/de/otto/edison/vault/VaultReaderTest.java
@@ -37,14 +37,14 @@ public class VaultReaderTest extends PowerMockTestCase {
     public void shouldReadPropertiesFromVaultAndSetThem() throws Exception {
         // given
         Set<String> propertiesToRead = new HashSet<>();
-        propertiesToRead.add("someKey1");
-        propertiesToRead.add("someKey2");
-        propertiesToRead.add("someKey3");
-
+        propertiesToRead.add("someKey1.value");
+        propertiesToRead.add("someKey2.value");
+        propertiesToRead.add("someKey3.field3");
+        propertiesToRead.add("someKey3.field3_2");
+        propertiesToRead.add("someKeyWithoutDot");
+        propertiesToRead.add("someKeyWithoutDot2");
         when(configProperties.getProperties()).thenReturn(propertiesToRead);
-        when(configProperties.getPropertyFieldnames("someKey1")).thenReturn(new HashSet<>(Arrays.asList("value")));
-        when(configProperties.getPropertyFieldnames("someKey2")).thenReturn(new HashSet<>(Arrays.asList("value")));
-        when(configProperties.getPropertyFieldnames("someKey3")).thenReturn(new HashSet<>(Arrays.asList("field3", "field3_2")));
+
         when(vaultClient.readFields("someKey1")).thenReturn(singletonMap("value", "someValue1"));
         when(vaultClient.readFields("someKey2")).thenReturn(singletonMap("value", "someValue2"));
 
@@ -53,17 +53,22 @@ public class VaultReaderTest extends PowerMockTestCase {
         someKey3Values.put("field3_2", "someValue3_2");
         when(vaultClient.readFields("someKey3")).thenReturn(someKey3Values);
 
+        final Map<String, String> dotlessValues = new HashMap<>();
+        dotlessValues.put("someKeyWithoutDot", "dotless1");
+        dotlessValues.put("someKeyWithoutDot2", "dotless2");
+        when(vaultClient.readFields("")).thenReturn(dotlessValues);
+
         // when
         Properties properties = testee.fetchPropertiesFromVault();
 
         // then
         Properties expectedProperties = new Properties();
-        expectedProperties.setProperty("someKey1", "someValue1");
-        expectedProperties.setProperty("someKey1@value", "someValue1");
-        expectedProperties.setProperty("someKey2", "someValue2");
-        expectedProperties.setProperty("someKey2@value", "someValue2");
-        expectedProperties.setProperty("someKey3@field3", "someValue3");
-        expectedProperties.setProperty("someKey3@field3_2", "someValue3_2");
+        expectedProperties.setProperty("someKey1.value", "someValue1");
+        expectedProperties.setProperty("someKey2.value", "someValue2");
+        expectedProperties.setProperty("someKey3.field3", "someValue3");
+        expectedProperties.setProperty("someKey3.field3_2", "someValue3_2");
+        expectedProperties.setProperty("someKeyWithoutDot", "dotless1");
+        expectedProperties.setProperty("someKeyWithoutDot2", "dotless2");
 
         assertThat(properties, is(expectedProperties));
     }


### PR DESCRIPTION
The previous mapping from the the spring property name to its vault path was not very good.

I've implemented a new way which will break all old implementation. Therefore I've startet a new major version.

I'm still looking for a way to provide an easy way to configure the mapping implementation. Unfortunately we cannot use spring because the reading from vault takes place before any bean is instanciated by spring...