### PR TITLE
Revert "Make Vault-Token name configurable via property"

### DIFF
--- a/src/main/java/de/otto/edison/vault/ConfigProperties.java
+++ b/src/main/java/de/otto/edison/vault/ConfigProperties.java
@@ -1,13 +1,12 @@
 package de.otto.edison.vault;
 
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.Optional;
-import java.util.Set;
-import java.util.stream.Collectors;
-
 import org.springframework.core.env.Environment;
 import org.springframework.util.StringUtils;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 public class ConfigProperties {
 
@@ -20,7 +19,6 @@ public class ConfigProperties {
     private final String fileToken;
     private final String appId;
     private final String userId;
-    private final String tokenFileName;
     private final String defaultVaultToken;
 
     public ConfigProperties(Environment environment) {
@@ -34,9 +32,8 @@ public class ConfigProperties {
         fileToken = environment.getProperty("edison.vault.file-token");
         appId = environment.getProperty("edison.vault.appid");
         userId = environment.getProperty("edison.vault.userid");
-        tokenFileName = Optional.ofNullable(environment.getProperty("edison.vault.token-filename")).orElse(".vault-token") ;
         final String homeDir = environment.getProperty("user.home");
-        defaultVaultToken = homeDir + "/" + tokenFileName;
+        defaultVaultToken = homeDir + "/.vault-token";
     }
 
     public boolean isEnabled() {
@@ -73,10 +70,6 @@ public class ConfigProperties {
 
     public String getUserId() {
         return userId;
-    }
-
-    public String getTokenFileName() {
-        return tokenFileName;
     }
 
     public String getDefaultVaultTokenFileName() {
@@ -133,9 +126,6 @@ public class ConfigProperties {
         if (userId != null ? !userId.equals(that.userId) : that.userId != null) {
             return false;
         }
-        if (tokenFileName != null ? !tokenFileName.equals(that.tokenFileName) : that.tokenFileName != null) {
-            return false;
-        }
         return defaultVaultToken != null ? defaultVaultToken.equals(that.defaultVaultToken) : that.defaultVaultToken == null;
     }
 
@@ -150,7 +140,6 @@ public class ConfigProperties {
         result = 31 * result + (fileToken != null ? fileToken.hashCode() : 0);
         result = 31 * result + (appId != null ? appId.hashCode() : 0);
         result = 31 * result + (userId != null ? userId.hashCode() : 0);
-        result = 31 * result + (tokenFileName != null ? tokenFileName.hashCode() : 0);
         result = 31 * result + (defaultVaultToken != null ? defaultVaultToken.hashCode() : 0);
         return result;
     }
@@ -167,7 +156,6 @@ public class ConfigProperties {
                 ", fileToken='" + fileToken + '\'' +
                 ", appId='" + appId + '\'' +
                 ", userId='" + userId + '\'' +
-                ", tokenFileName='" + tokenFileName + '\'' +
                 ", defaultVaultToken='" + defaultVaultToken + '\'' +
                 '}';
     }

--- a/src/test/java/de/otto/edison/vault/ConfigPropertiesTest.java
+++ b/src/test/java/de/otto/edison/vault/ConfigPropertiesTest.java
@@ -1,14 +1,15 @@
 package de.otto.edison.vault;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.hasItems;
-import static org.hamcrest.core.Is.is;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
-
 import org.hamcrest.Matchers;
 import org.springframework.core.env.Environment;
 import org.testng.annotations.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasItems;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.core.Is.is;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public class ConfigPropertiesTest {
 
@@ -25,7 +26,6 @@ public class ConfigPropertiesTest {
         when(environment.getProperty("edison.vault.file-token")).thenReturn("someFile");
         when(environment.getProperty("edison.vault.appid")).thenReturn("someAppId");
         when(environment.getProperty("edison.vault.userid")).thenReturn("someUserId");
-        when(environment.getProperty("edison.vault.token-filename")).thenReturn("someFilename");
 
         // When
         ConfigProperties testee = new ConfigProperties(environment);
@@ -39,35 +39,6 @@ public class ConfigPropertiesTest {
         assertThat(testee.getTokenSource(), is("file"));
         assertThat(testee.getAppId(), is("someAppId"));
         assertThat(testee.getUserId(), is("someUserId"));
-        assertThat(testee.getTokenFileName(), is("someFilename"));
-
-    }
-
-    @Test
-    public void shouldSetDefaultTokenFileName() throws Exception {
-        // Given
-        Environment environment = mock(Environment.class);
-        when(environment.getProperty("edison.vault.token-filename")).thenReturn(null);
-
-        // When
-        ConfigProperties testee = new ConfigProperties(environment);
-
-        // Then
-        assertThat(testee.getTokenFileName(), is(".vault-token"));
-
-    }
-
-    @Test
-    public void shouldSetDefaultToken() throws Exception {
-        // Given
-        Environment environment = mock(Environment.class);
-        when(environment.getProperty("user.home")).thenReturn("/test");
-
-        // When
-        ConfigProperties testee = new ConfigProperties(environment);
-
-        // Then
-        assertThat(testee.getDefaultVaultTokenFileName(), is("/test/.vault-token"));
 
     }
 }


### PR DESCRIPTION
This reverts commit f26e613

functionality already exist with "fileToken" property